### PR TITLE
Add cmake to linux

### DIFF
--- a/src/Cake.CMake/CMakeRunner.cs
+++ b/src/Cake.CMake/CMakeRunner.cs
@@ -70,7 +70,7 @@ namespace Cake.CMake
         /// <returns>The CMake executable name.</returns>
         protected override IEnumerable<string> GetToolExecutableNames()
         {
-            return new[] { "cmake.exe" };
+            return new[] { "cmake.exe", "cmake" };
         }
 
         /// <summary>


### PR DESCRIPTION
This fixes #2. I verified that I can still build cmake projects on windows and can also now build them on my linux VM.

I'll try to make another pull request adding build.sh to this project and a unit test soon if that is something that is desired.
