### PR TITLE
add support for platform name command line switch

### DIFF
--- a/src/Cake.CMake.Tests/CMakeRunnerTests.cs
+++ b/src/Cake.CMake.Tests/CMakeRunnerTests.cs
@@ -227,6 +227,23 @@ namespace Cake.CMake.Tests
                     Arg.Is<ProcessSettings>(
                         p => p.Arguments.Render() == "\"/Working/source\" -T \"cool_toolset\""));
             }
+
+            [Fact]
+            public void Should_Append_Platform_To_Arguments()
+            {
+                // Given
+                var fixture = new CMakeRunnerFixture();
+                fixture.Settings.Platform = "x64";
+
+                // When
+                fixture.Run();
+
+                // Then
+                fixture.ProcessRunner.Received(1).Start(
+                    Arg.Any<FilePath>(),
+                    Arg.Is<ProcessSettings>(
+                        p => p.Arguments.Render() == "\"/Working/source\" -A \"x64\""));
+            }
         }
     }
 }

--- a/src/Cake.CMake/CMakeRunner.cs
+++ b/src/Cake.CMake/CMakeRunner.cs
@@ -111,6 +111,13 @@ namespace Cake.CMake
                 builder.AppendQuoted(settings.Toolset);
             }
 
+            // Platform
+            if (!string.IsNullOrWhiteSpace(settings.Platform))
+            {
+                builder.Append("-A");
+                builder.AppendQuoted(settings.Platform);
+            }
+
             return builder;
         }
     }

--- a/src/Cake.CMake/CMakeSettings.cs
+++ b/src/Cake.CMake/CMakeSettings.cs
@@ -21,6 +21,12 @@ namespace Cake.CMake
         public string Toolset { get; set; }
 
         /// <summary>
+        /// Gets or sets the platform name.
+        /// </summary>
+        /// <value>The platform name.</value>
+        public string Platform { get; set; }
+
+        /// <summary>
         /// Gets or sets the output path.
         /// </summary>
         /// <value>The output path.</value>


### PR DESCRIPTION
Hi!

This PR contains adding support for -A command line specifier.
It turns out that -A command line specifier is appeared in cmake v3.1: https://cmake.org/cmake/help/v3.1/manual/cmake.1.html

In Visual Studio generator Win32, x64 and ARM platform names is supported.
It is more convinient to specify only platform name and use default generator, instead of specifiing generator like "Visual Studio 14 2015 Win64" for x64 platform.

Would you like to accept this PR?
