### PR TITLE
Upgrade Cake to 0.17.0

### DIFF
--- a/Source/Cake.CMake.Tests/Cake.CMake.Tests.csproj
+++ b/Source/Cake.CMake.Tests/Cake.CMake.Tests.csproj
@@ -33,12 +33,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Core, Version=0.10.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Core.0.10.1\lib\net45\Cake.Core.dll</HintPath>
+    <Reference Include="Cake.Core, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Core.0.17.0\lib\net45\Cake.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NSubstitute, Version=1.9.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
-      <HintPath>..\packages\NSubstitute.1.9.0.0\lib\net45\NSubstitute.dll</HintPath>
+    <Reference Include="Cake.Testing, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Testing.0.17.1\lib\net45\Cake.Testing.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Source/Cake.CMake.Tests/packages.config
+++ b/Source/Cake.CMake.Tests/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.10.1" targetFramework="net45" />
+  <package id="Cake.Core" version="0.17.0" targetFramework="net45" />
+  <package id="Cake.Testing" version="0.17.1" targetFramework="net45" />
   <package id="gep13.xUnitRunner" version="0.1.0" targetFramework="net45" />
-  <package id="NSubstitute" version="1.9.0.0" targetFramework="net45" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net45" />

--- a/Source/Cake.CMake/CMakeAliases.cs
+++ b/Source/Cake.CMake/CMakeAliases.cs
@@ -25,7 +25,7 @@ namespace Cake.CMake
                 throw new ArgumentNullException(nameof(context));
             }
 
-            var runner = new CMakeRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber);
+            var runner = new CMakeRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
             runner.Run(sourcePath, settings);
         }
     }

--- a/Source/Cake.CMake/CMakeRunner.cs
+++ b/Source/Cake.CMake/CMakeRunner.cs
@@ -19,9 +19,9 @@ namespace Cake.CMake
         /// <param name="fileSystem">The file system.</param>
         /// <param name="environment">The environment.</param>
         /// <param name="processRunner">The process runner.</param>
-        /// <param name="globber">The globber.</param>
-        public CMakeRunner(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner processRunner, IGlobber globber)
-            : base(fileSystem, environment, processRunner, globber)
+        /// <param name="tools">The tool locator.</param>
+        public CMakeRunner(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner processRunner, IToolLocator tools)
+            : base(fileSystem, environment, processRunner,  tools)
         {
             _environment = environment;
         }
@@ -80,7 +80,7 @@ namespace Cake.CMake
         /// <returns>The alternative tool paths to CMake.</returns>
         protected override IEnumerable<FilePath> GetAlternativeToolPaths(CMakeSettings settings)
         {
-            if (!_environment.IsUnix())
+            if (!_environment.Platform.IsUnix())
             {
                 var programFiles = _environment.GetSpecialPath(SpecialPath.ProgramFilesX86);
                 var cmakePath = programFiles.Combine("cmake/bin").CombineWithFilePath("cmake.exe");

--- a/Source/Cake.CMake/Cake.CMake.csproj
+++ b/Source/Cake.CMake/Cake.CMake.csproj
@@ -35,8 +35,8 @@
     <DocumentationFile>bin\Release\Cake.CMake.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Core, Version=0.10.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Core.0.10.1\lib\net45\Cake.Core.dll</HintPath>
+    <Reference Include="Cake.Core, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Core.0.17.0\lib\net45\Cake.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Source/Cake.CMake/packages.config
+++ b/Source/Cake.CMake/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.10.1" targetFramework="net45" />
+  <package id="Cake.Core" version="0.17.0" targetFramework="net45" />
   <package id="gep13.ApplicationRunner" version="0.1.2" targetFramework="net45" />
 </packages>

--- a/setup.cake
+++ b/setup.cake
@@ -36,6 +36,7 @@ var sendMessageToTwitter = true;
 var rootDirectoryPath         = MakeAbsolute(Context.Environment.WorkingDirectory);
 var solutionFilePath          = "./Source/Cake.CMake.sln";
 var solutionDirectoryPath     = "./Source/Cake.CMake";
+var sourceDirectoryPath       = "./Source";
 var title                     = "Cake.CMake";
 var resharperSettingsFileName = "Cake.CMake.sln.DotSettings";
 var repositoryOwner           = "cake-contrib";
@@ -45,6 +46,9 @@ var appVeyorProjectSlug       = "cake-cmake";
 
 // NOTE: Only populate this, if required, but leave as is otherwise.
 var dupFinderExcludePattern   = new string[] { };
+var testCoverageFilter = "+[*]* -[xunit.*]* -[Cake.Core]* -[Cake.Testing]* -[*.Tests]* ";
+var testCoverageExcludeByAttribute = "*.ExcludeFromCodeCoverage*";
+var testCoverageExcludeByFile = "*/*Designer.cs;*/*.g.cs;*/*.g.i.cs";
 
 ///////////////////////////////////////////////////////////////////////////////
 // CAKE FILES TO LOAD IN


### PR DESCRIPTION
Cake 0.18.0 will requires at least version 0.16.x to work.

Switched from NSubstitute to Cake.Testing