### PR TITLE
fix Cake.CMake Version=0.1.2.0 is referencing an older version of Cake.Core (0.10.1) error

### DIFF
--- a/src/Cake.CMake/Cake.CMake.csproj
+++ b/src/Cake.CMake/Cake.CMake.csproj
@@ -38,6 +38,7 @@
     <Reference Include="Cake.Core, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Cake.Core.0.17.0\lib\net45\Cake.Core.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
fix for #10 