### PR TITLE
(build) Change load pre-processor directive

### DIFF
--- a/setup.cake
+++ b/setup.cake
@@ -1,4 +1,4 @@
-#load "nuget:https://www.myget.org/F/cake-contrib/api/v2?package=Cake.Recipe&version=1.0.0"
+#load nuget:?package=Cake.Recipe&version=1.0.0
 
 Environment.SetVariableNames();
 


### PR DESCRIPTION
Pinning to 1.0.0 is absolutely the right thing to do, however, getting from MyGet isn't recommended.  There
is no guarantee that packages pushed to MyGet will remain (there are retention rules in place which might
mean a package version is deleted).  The recommendation would be to get the released version from 
NuGet.org, which is what this change does.